### PR TITLE
Add planar mechanism simulation package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.mypy_cache/
+pytest_cache/
+mechanism_demo_log.txt

--- a/examples/line_mechanism_demo.py
+++ b/examples/line_mechanism_demo.py
@@ -1,0 +1,43 @@
+"""Demonstration of a simple line-based mechanism simulation."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+from mechanism_sim import Link, Joint, Mechanism, MechanismSimulator, collision
+
+
+def build_mechanism() -> Mechanism:
+    links = [
+        Link(name="link1", length=1.0),
+        Link(name="link2", length=0.8),
+        Link(name="link3", length=0.6),
+    ]
+    joints = [
+        Joint(name="joint1", angle=math.radians(30), angular_velocity=math.radians(15)),
+        Joint(name="joint2", angle=math.radians(-20), angular_velocity=math.radians(10)),
+        Joint(name="joint3", angle=math.radians(10), angular_velocity=math.radians(-5)),
+    ]
+    return Mechanism(base_position=(0.0, 0.0), links=links, joints=joints)
+
+
+def run_demo(steps: int = 10, dt: float = 0.1) -> None:
+    mechanism = build_mechanism()
+    simulator = MechanismSimulator(mechanism)
+
+    log_path = Path("mechanism_demo_log.txt")
+    with log_path.open("w", encoding="utf-8") as log_file:
+        for result in simulator.run(dt=dt, steps=steps):
+            collisions = collision.detect_self_collision(result.segments)
+            log_file.write(
+                f"time={result.time:.2f} segments={result.segments} collisions={collisions}\n"
+            )
+            print(
+                f"t={result.time:.2f}s -> end effector at {result.segments[-1][1]}, collisions={collisions}"
+            )
+    print(f"Simulation log written to {log_path.resolve()}")
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/src/mechanism_sim/__init__.py
+++ b/src/mechanism_sim/__init__.py
@@ -1,0 +1,13 @@
+"""Mechanism simulation package."""
+
+from .model import Link, Joint, Mechanism
+from .simulation import MechanismSimulator
+from . import collision
+
+__all__ = [
+    "Link",
+    "Joint",
+    "Mechanism",
+    "MechanismSimulator",
+    "collision",
+]

--- a/src/mechanism_sim/collision.py
+++ b/src/mechanism_sim/collision.py
@@ -1,0 +1,63 @@
+"""Collision detection utilities for planar mechanisms."""
+
+from __future__ import annotations
+
+from typing import List, Sequence, Tuple
+
+from .model import Mechanism, Point
+
+Segment = Tuple[Point, Point]
+EPSILON = 1e-9
+
+
+def _orientation(p: Point, q: Point, r: Point) -> float:
+    return (q[0] - p[0]) * (r[1] - p[1]) - (q[1] - p[1]) * (r[0] - p[0])
+
+
+def _on_segment(p: Point, q: Point, r: Point) -> bool:
+    return (
+        min(p[0], r[0]) - EPSILON <= q[0] <= max(p[0], r[0]) + EPSILON
+        and min(p[1], r[1]) - EPSILON <= q[1] <= max(p[1], r[1]) + EPSILON
+    )
+
+
+def segments_intersect(seg1: Segment, seg2: Segment, *, inclusive: bool = True) -> bool:
+    """Return ``True`` if the two line segments intersect."""
+
+    (p1, q1) = seg1
+    (p2, q2) = seg2
+
+    o1 = _orientation(p1, q1, p2)
+    o2 = _orientation(p1, q1, q2)
+    o3 = _orientation(p2, q2, p1)
+    o4 = _orientation(p2, q2, q1)
+
+    if abs(o1) <= EPSILON and _on_segment(p1, p2, q1):
+        return inclusive
+    if abs(o2) <= EPSILON and _on_segment(p1, q2, q1):
+        return inclusive
+    if abs(o3) <= EPSILON and _on_segment(p2, p1, q2):
+        return inclusive
+    if abs(o4) <= EPSILON and _on_segment(p2, q1, q2):
+        return inclusive
+
+    return (o1 > 0) != (o2 > 0) and (o3 > 0) != (o4 > 0)
+
+
+def detect_self_collision(segments: Sequence[Segment]) -> List[Tuple[int, int]]:
+    """Detect intersecting pairs among ``segments``."""
+
+    collisions: List[Tuple[int, int]] = []
+    for i in range(len(segments)):
+        for j in range(i + 2, len(segments)):
+            # Adjacent links share a joint and are expected to touch.
+            if segments_intersect(segments[i], segments[j]):
+                collisions.append((i, j))
+    return collisions
+
+
+def mechanism_self_collision(mechanism: Mechanism) -> List[Tuple[int, int]]:
+    """Convenience wrapper using a :class:`Mechanism`."""
+
+    segments = mechanism.forward_kinematics()
+    return detect_self_collision(segments)

--- a/src/mechanism_sim/model.py
+++ b/src/mechanism_sim/model.py
@@ -1,0 +1,92 @@
+"""Data models describing planar mechanisms."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import math
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+Point = Tuple[float, float]
+
+
+def _validate_lengths(lengths: Iterable[float]) -> None:
+    for length in lengths:
+        if length <= 0:
+            raise ValueError("Link lengths must be positive.")
+
+
+@dataclass
+class Link:
+    """A rigid link represented by its length."""
+
+    name: str
+    length: float
+
+    def __post_init__(self) -> None:
+        _validate_lengths([self.length])
+
+
+@dataclass
+class Joint:
+    """A revolute joint connecting two links."""
+
+    name: str
+    angle: float = 0.0
+    angular_velocity: float = 0.0
+
+
+@dataclass
+class Mechanism:
+    """A simple serial-chain planar mechanism."""
+
+    base_position: Point
+    links: Sequence[Link]
+    joints: Sequence[Joint]
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if len(self.links) != len(self.joints):
+            raise ValueError("Mechanism must have the same number of links and joints.")
+        _validate_lengths(link.length for link in self.links)
+
+    @property
+    def dof(self) -> int:
+        """Return the number of degrees of freedom."""
+
+        return len(self.joints)
+
+    def joint_by_name(self, name: str) -> Joint:
+        """Retrieve a joint by name."""
+
+        for joint in self.joints:
+            if joint.name == name:
+                return joint
+        raise KeyError(f"Joint '{name}' not found")
+
+    def forward_kinematics(self) -> List[Tuple[Point, Point]]:
+        """Compute the start and end positions of each link."""
+
+        x, y = self.base_position
+        theta = 0.0
+        segments: List[Tuple[Point, Point]] = []
+        for link, joint in zip(self.links, self.joints):
+            theta += joint.angle
+            start = (x, y)
+            x += link.length * math.cos(theta)
+            y += link.length * math.sin(theta)
+            end = (x, y)
+            segments.append((start, end))
+        return segments
+
+    def snapshot(self) -> Dict[str, object]:
+        """Return a serialisable view of the mechanism state."""
+
+        return {
+            "base_position": self.base_position,
+            "joints": [
+                {"name": joint.name, "angle": joint.angle, "angular_velocity": joint.angular_velocity}
+                for joint in self.joints
+            ],
+            "segments": self.forward_kinematics(),
+            "metadata": dict(self.metadata),
+        }

--- a/src/mechanism_sim/simulation.py
+++ b/src/mechanism_sim/simulation.py
@@ -1,0 +1,92 @@
+"""Simulation utilities for planar mechanisms."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
+
+from .model import Mechanism
+
+ControlInput = Dict[str, float]
+
+
+@dataclass
+class SimulationResult:
+    """Represents a single simulation step result."""
+
+    time: float
+    segments: List[tuple]
+    snapshot: Dict[str, object]
+
+
+@dataclass
+class MechanismSimulator:
+    """Advance a :class:`Mechanism` through time."""
+
+    mechanism: Mechanism
+    time: float = 0.0
+    history: List[SimulationResult] = field(default_factory=list)
+
+    def forward_kinematics(self) -> List[tuple]:
+        """Compute current link positions."""
+
+        return self.mechanism.forward_kinematics()
+
+    def step(self, dt: float, controls: Optional[ControlInput] = None) -> SimulationResult:
+        """Advance the mechanism by ``dt`` seconds.
+
+        Parameters
+        ----------
+        dt:
+            Time increment.
+        controls:
+            Optional mapping of joint names to angular velocities.
+        """
+
+        if dt <= 0:
+            raise ValueError("Time step must be positive.")
+
+        if controls is not None:
+            self._apply_controls(controls)
+
+        for joint in self.mechanism.joints:
+            joint.angle += joint.angular_velocity * dt
+
+        self.time += dt
+        snapshot = self.mechanism.snapshot()
+        result = SimulationResult(time=self.time, segments=snapshot["segments"], snapshot=snapshot)
+        self.history.append(result)
+        return result
+
+    def run(self, dt: float, steps: int, controller: Optional[Callable[[float, Mechanism], ControlInput]] = None) -> List[SimulationResult]:
+        """Run ``steps`` iterations of size ``dt``.
+
+        A controller function can be provided which receives the current
+        simulation time and mechanism, returning control inputs for the next
+        step.
+        """
+
+        results: List[SimulationResult] = []
+        for _ in range(steps):
+            if controller is None:
+                controls = None
+            else:
+                controls = controller(self.time, self.mechanism)
+            results.append(self.step(dt, controls=controls))
+        return results
+
+    def _apply_controls(self, controls: ControlInput) -> None:
+        """Update joint angular velocities according to ``controls``."""
+
+        for name, angular_velocity in controls.items():
+            joint = self.mechanism.joint_by_name(name)
+            joint.angular_velocity = angular_velocity
+
+    def reset(self) -> None:
+        """Reset the simulator state and clear history."""
+
+        self.time = 0.0
+        self.history.clear()
+        for joint in self.mechanism.joints:
+            joint.angle = 0.0
+            joint.angular_velocity = 0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -1,0 +1,40 @@
+import math
+
+from mechanism_sim import collision
+from mechanism_sim.model import Link, Joint, Mechanism
+
+
+def make_crossing_segments():
+    return [((0.0, 0.0), (1.0, 1.0)), ((0.0, 1.0), (1.0, 0.0))]
+
+
+def test_segments_intersect_crossing():
+    seg1, seg2 = make_crossing_segments()
+    assert collision.segments_intersect(seg1, seg2)
+
+
+def test_segments_intersect_touching():
+    seg1 = ((0.0, 0.0), (1.0, 0.0))
+    seg2 = ((1.0, 0.0), (2.0, 0.0))
+    assert collision.segments_intersect(seg1, seg2)
+
+
+def test_mechanism_self_collision_detects():
+    links = [Link("l1", 1.0), Link("l2", 1.0), Link("l3", 1.0)]
+    joints = [
+        Joint("j1", angle=0.0),
+        Joint("j2", angle=math.pi),
+        Joint("j3", angle=0.0),
+    ]
+    mechanism = Mechanism(base_position=(0.0, 0.0), links=links, joints=joints)
+    collisions = collision.mechanism_self_collision(mechanism)
+    assert collisions == [(0, 2)]
+
+
+def test_detect_self_collision_skip_neighbors():
+    segments = [
+        ((0.0, 0.0), (1.0, 0.0)),
+        ((1.0, 0.0), (2.0, 0.0)),
+        ((2.0, 0.0), (3.0, 0.0)),
+    ]
+    assert collision.detect_self_collision(segments) == []

--- a/tests/test_model_and_simulation.py
+++ b/tests/test_model_and_simulation.py
@@ -1,0 +1,31 @@
+import math
+
+import pytest
+
+from mechanism_sim.model import Link, Joint, Mechanism
+from mechanism_sim.simulation import MechanismSimulator
+
+
+def test_forward_kinematics_chain():
+    links = [Link("l1", 1.0), Link("l2", 1.0)]
+    joints = [Joint("j1", angle=0.0), Joint("j2", angle=math.pi / 2)]
+    mechanism = Mechanism(base_position=(0.0, 0.0), links=links, joints=joints)
+
+    segments = mechanism.forward_kinematics()
+    assert segments[0] == ((0.0, 0.0), (1.0, 0.0))
+    end_of_second = segments[1][1]
+    assert pytest.approx(end_of_second[0], rel=1e-6) == 1.0
+    assert pytest.approx(end_of_second[1], rel=1e-6) == 1.0
+
+
+def test_simulator_step_updates_angles():
+    links = [Link("l1", 1.0)]
+    joints = [Joint("j1", angle=0.0, angular_velocity=math.pi)]
+    mechanism = Mechanism(base_position=(0.0, 0.0), links=links, joints=joints)
+    simulator = MechanismSimulator(mechanism)
+
+    simulator.step(0.5)
+    assert math.isclose(mechanism.joints[0].angle, math.pi * 0.5)
+
+    simulator.step(0.5, controls={"j1": math.pi / 2})
+    assert math.isclose(mechanism.joints[0].angle, math.pi * 0.75)


### PR DESCRIPTION
## Summary
- add a new `mechanism_sim` package with data structures, simulation utilities, and collision checks for planar mechanisms
- provide an example script that simulates a simple multi-link mechanism and logs the motion
- cover the forward kinematics and collision helpers with pytest unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2a8dddeec832885ca7b684e47b893